### PR TITLE
fix mesh_path output for sculpting model

### DIFF
--- a/src/csm/client.py
+++ b/src/csm/client.py
@@ -505,7 +505,7 @@ class CSMClient:
         # download mesh file based on the requested format
         if mesh_format == 'obj':
             mesh_url = result['data']['preview_mesh_url_zip']
-            mesh_file = 'mesh.zip'
+            mesh_file = 'mesh.obj' if preview_model == 'fast_sculpt' else 'mesh.zip'
         elif mesh_format == 'glb':
             mesh_url = result['data']['preview_mesh_url_glb']
             mesh_file = 'mesh.glb'


### PR DESCRIPTION
Return _mesh.obj_ instead of _mesh.zip_ when `preview_model="fast_sculpt"`. The sculpting model does not have a zip.