### PR TITLE
Updates mar24

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ result = csm_client.text_to_3d(prompt, mesh_format='obj')
 print(result.mesh_path)
 ```
 
-**Mesh formats:** Choose any of ['obj', 'glb', 'usdz'] for the `mesh_format` argument.
+**Mesh formats:** Choose any of ['obj', 'glb', 'fbx', 'usdz'] for the `mesh_format` argument.
 
 **Verbose mode:** Run client functions with option `verbose=True` (the default) to see additional status messages and logs.
 

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -32,6 +32,6 @@ Run text-to-3d inference:
     print(result.mesh_path)
 
 
-**Mesh formats:** Choose any of ['obj', 'glb', 'usdz'] for the `mesh_format` argument.
+**Mesh formats:** Choose any of ['obj', 'glb', 'fbx', 'usdz'] for the `mesh_format` argument.
 
 **Verbose mode:** Run client functions with option `verbose=True` (the default) to see additional status messages and logs.

--- a/src/csm/client.py
+++ b/src/csm/client.py
@@ -285,7 +285,7 @@ class CSMClient:
         self,
         image,
         *,
-        mesh_format='obj',
+        mesh_format='glb',
         output='./',
         timeout=_DEFAULT_TIMEOUT,
         verbose=None,
@@ -303,7 +303,7 @@ class CSMClient:
             :class:`PIL.Image.Image` instance.
         mesh_format : str, optional
             The format of the output 3D mesh file. Choices are ['obj', 'glb', 'fbx', 'usdz'].
-            Defaults to 'obj'.
+            Defaults to 'glb'.
         output : str, optional
             The directory path where output files will be saved.
         timeout : int, optional
@@ -396,7 +396,7 @@ class CSMClient:
             *,
             style_id="",
             guidance=6,
-            mesh_format='obj',
+            mesh_format='glb',
             output='./',
             timeout=_DEFAULT_TIMEOUT,
             verbose=None,
@@ -416,7 +416,7 @@ class CSMClient:
             the generation follows the input text. Default is 6.
         mesh_format : str, optional
             The format of the output 3D mesh file. Choices are ['obj', 'glb', 'fbx', 'usdz'].
-            Defaults to 'obj'.
+            Defaults to 'glb'.
         output : str, optional
             The directory path where output files (mesh and video, if generated) 
             will be saved. Defaults to the current directory.

--- a/src/csm/client.py
+++ b/src/csm/client.py
@@ -301,7 +301,7 @@ class CSMClient:
             The input image. May be provided as a URL, a local file path, or a 
             :class:`PIL.Image.Image` instance.
         mesh_format : str, optional
-            The format of the output 3D mesh file. Choices are 'obj', 'glb', or 'usdz'. 
+            The format of the output 3D mesh file. Choices are ['obj', 'glb', 'fbx', 'usdz'].
             Defaults to 'obj'.
         output : str, optional
             The directory path where output files will be saved.
@@ -331,10 +331,11 @@ class CSMClient:
             warnings.warn("The option for `preview_model` has been deprecated and has been removed.", DeprecationWarning)
 
         mesh_format = mesh_format.lower()
-        if mesh_format not in ['obj', 'glb', 'usdz']:
+        allowed_formats = ['obj', 'zip', 'glb', 'fbx', 'usdz']
+        if mesh_format not in allowed_formats:
             raise ValueError(
                 f"Unexpected mesh_format value ('{mesh_format}'). Please choose "
-                f"from options ['obj', 'glb', 'usdz']."
+                f"from options {allowed_formats}."
             )
 
         image_url = self._handle_image_input(image)
@@ -380,18 +381,8 @@ class CSMClient:
         self.log(f'image-to-3d completed in {run_time:.1f}s')
 
         # download mesh file based on the requested format
-        if mesh_format == 'obj':
-            mesh_url = result['data']['preview_mesh_url']
-            mesh_file = 'mesh.obj'
-        elif mesh_format == 'glb':
-            mesh_url = result['data']['preview_mesh_url_glb']
-            mesh_file = 'mesh.glb'
-        elif mesh_format == 'usdz':
-            mesh_url = result['data']['preview_mesh_url_usdz']
-            mesh_file = 'mesh.usdz'
-        else:
-            raise ValueError(f"Encountered unexpected mesh_format value ('{mesh_format}').")
-
+        mesh_url = result['data'][f'mesh_url_{mesh_format}']
+        mesh_file = f'mesh.{mesh_format}'
         mesh_path = os.path.join(output, mesh_file)  # TODO: os.path.abspath ?
         urlretrieve(mesh_url, mesh_path)
 
@@ -422,7 +413,7 @@ class CSMClient:
             A parameter that adjusts guidance strength, affecting how closely 
             the generation follows the input text. Default is 6.
         mesh_format : str, optional
-            The format of the output 3D mesh file. Choices are 'obj', 'glb', or 'usdz'.
+            The format of the output 3D mesh file. Choices are ['obj', 'glb', 'fbx', 'usdz'].
             Defaults to 'obj'.
         output : str, optional
             The directory path where output files (mesh and video, if generated) 

--- a/src/csm/client.py
+++ b/src/csm/client.py
@@ -2,6 +2,7 @@ import os
 import time
 import warnings
 from urllib.request import urlretrieve
+from urllib.parse import urlparse
 from dataclasses import dataclass
 import requests
 import base64
@@ -382,7 +383,8 @@ class CSMClient:
 
         # download mesh file based on the requested format
         mesh_url = result['data'][f'mesh_url_{mesh_format}']
-        mesh_file = f'mesh.{mesh_format}'
+        #mesh_file = f'mesh.{mesh_format}'
+        mesh_file = os.path.basename(urlparse(mesh_url).path)
         mesh_path = os.path.join(output, mesh_file)  # TODO: os.path.abspath ?
         urlretrieve(mesh_url, mesh_path)
 

--- a/src/csm/client.py
+++ b/src/csm/client.py
@@ -10,9 +10,6 @@ import PIL.Image
 from io import BytesIO
 
 
-_DEFAULT_TIMEOUT = 1000  # in seconds
-
-
 class BackendClient:
     """A backend client class for raw GET/POST requests to the REST API.
 
@@ -287,7 +284,8 @@ class CSMClient:
         *,
         mesh_format='glb',
         output='./',
-        timeout=_DEFAULT_TIMEOUT,
+        timeout=1000,
+        poll_interval=5,
         verbose=None,
         **kwargs
     ) -> ImageTo3DResult:
@@ -308,6 +306,8 @@ class CSMClient:
             The directory path where output files will be saved.
         timeout : int, optional
             The maximum time (in seconds) to wait for the 3D mesh generation.
+        poll_interval : int
+            Time to wait (in seconds) between iterations while polling for a result.
         verbose : bool, optional
             If True, outputs detailed progress information. Defaults to `self.verbose`.
         **kwargs : dict, optional
@@ -361,7 +361,7 @@ class CSMClient:
         start_time = time.time()
         run_time = 0.
         while True:
-            time.sleep(2)
+            time.sleep(poll_interval)
             result = self.backend.get_image_to_3d_session_info(session_code)
             status = result['data']['session_status']
             percent_done = result['data'].get('percent_done', 'N/A')
@@ -398,7 +398,8 @@ class CSMClient:
             guidance=6,
             mesh_format='glb',
             output='./',
-            timeout=_DEFAULT_TIMEOUT,
+            timeout=1000,
+            poll_interval=5,
             verbose=None,
             **kwargs
         ) -> TextTo3DResult:
@@ -422,7 +423,8 @@ class CSMClient:
             will be saved. Defaults to the current directory.
         timeout : int, optional
             The maximum time (in seconds) to wait for the 3D mesh generation. 
-            Defaults to 200 seconds.
+        poll_interval : int
+            Time to wait (in seconds) between iterations while polling for a result.
         verbose : bool, optional
             If True, outputs detailed progress information. Defaults to `self.verbose`.
         **kwargs : dict, optional
@@ -466,7 +468,7 @@ class CSMClient:
         start_time = time.time()
         run_time = 0.
         while True:
-            time.sleep(2)
+            time.sleep(poll_interval)
             result = self.backend.get_text_to_image_session_info(session_code)
             status = result['data']['status']
             if status == 'completed':
@@ -492,6 +494,7 @@ class CSMClient:
             mesh_format=mesh_format,
             output=output,
             timeout=timeout,
+            poll_interval=poll_interval,
             **kwargs
         )
 


### PR DESCRIPTION
Updates in this PR:
- Use "session_status" vs. "status" and update status value checks
- Update allowed `mesh_format` values (include "zip" and "fbx")
- Update mesh URL result key for each `mesh_format`
- Change default `mesh_format` value to "glb"
- Refactor verbosity: new `CSMClient.log` utility replaces `if verbose` blocks
- New `poll_interval` argument to controlling polling frequency while waiting for result